### PR TITLE
ユーザー登録・削除は管理者権限のみできるようにした

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,0 +1,4 @@
+ADMIN_PASSWORD="password"
+SENDGRID_USERNAME="example@heroku.com"
+SENDGRID_PASSWORD="password"
+HOST_URL="example.com"

--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,7 @@
 
 # Ignore bundler config.
 /.bundle
-
+.env
 # Ignore the default SQLite database.
 /db/*.sqlite3
 /db/*.sqlite3-journal

--- a/Gemfile
+++ b/Gemfile
@@ -35,7 +35,7 @@ gem 'devise'
 gem 'market_bot'
 
 gem 'seed-fu'
-gem 'dotenv-rails'
+
 
 gem "less-rails"
 gem "twitter-bootstrap-rails"
@@ -43,6 +43,7 @@ gem "twitter-bootstrap-rails"
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
+  gem 'dotenv-rails'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,6 @@ gem 'market_bot'
 
 gem 'seed-fu'
 
-
 gem "less-rails"
 gem "twitter-bootstrap-rails"
 
@@ -44,6 +43,8 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'byebug', platform: :mri
   gem 'dotenv-rails'
+  gem 'letter_opener'
+  gem 'letter_opener_web'
 end
 
 group :development do

--- a/Gemfile
+++ b/Gemfile
@@ -34,6 +34,9 @@ gem 'jbuilder', '~> 2.5'
 gem 'devise'
 gem 'market_bot'
 
+gem 'seed-fu'
+gem 'dotenv-rails'
+
 gem "less-rails"
 gem "twitter-bootstrap-rails"
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -38,6 +38,7 @@ GEM
       i18n (~> 0.7)
       minitest (~> 5.1)
       tzinfo (~> 1.1)
+    addressable (2.4.0)
     arel (7.0.0)
     bcrypt (3.1.11)
     builder (3.2.2)
@@ -77,6 +78,8 @@ GEM
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
+    launchy (2.4.3)
+      addressable (~> 2.3)
     less (2.6.0)
       commonjs (~> 0.2.7)
     less-rails (2.7.1)
@@ -84,6 +87,12 @@ GEM
       less (~> 2.6.0)
       sprockets (> 2, < 4)
       tilt
+    letter_opener (1.4.1)
+      launchy (~> 2.2)
+    letter_opener_web (1.3.0)
+      actionmailer (>= 3.2)
+      letter_opener (~> 1.0)
+      railties (>= 3.2)
     libv8 (3.16.14.15)
     listen (3.0.8)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -206,6 +215,8 @@ DEPENDENCIES
   jbuilder (~> 2.5)
   jquery-rails
   less-rails
+  letter_opener
+  letter_opener_web
   listen (~> 3.0.5)
   market_bot
   pg

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -58,6 +58,10 @@ GEM
       railties (>= 4.1.0, < 5.1)
       responders
       warden (~> 1.2.3)
+    dotenv (2.1.1)
+    dotenv-rails (2.1.1)
+      dotenv (= 2.1.1)
+      railties (>= 4.0, < 5.1)
     erubis (2.7.0)
     ethon (0.9.0)
       ffi (>= 1.3.0)
@@ -146,6 +150,9 @@ GEM
       sprockets (>= 2.8, < 4.0)
       sprockets-rails (>= 2.0, < 4.0)
       tilt (>= 1.1, < 3)
+    seed-fu (2.3.6)
+      activerecord (>= 3.1)
+      activesupport (>= 3.1)
     spring (1.7.2)
     spring-watcher-listen (2.0.0)
       listen (>= 2.7, < 4.0)
@@ -195,6 +202,7 @@ DEPENDENCIES
   byebug
   coffee-rails (~> 4.2)
   devise
+  dotenv-rails
   jbuilder (~> 2.5)
   jquery-rails
   less-rails
@@ -204,6 +212,7 @@ DEPENDENCIES
   puma (~> 3.0)
   rails (~> 5.0.0)
   sass-rails (~> 5.0)
+  seed-fu
   spring
   spring-watcher-listen (~> 2.0.0)
   therubyracer
@@ -212,6 +221,9 @@ DEPENDENCIES
   tzinfo-data
   uglifier (>= 1.3.0)
   web-console
+
+RUBY VERSION
+   ruby 2.3.1p112
 
 BUNDLED WITH
    1.12.4

--- a/app/assets/javascripts/users.coffee
+++ b/app/assets/javascripts/users.coffee
@@ -1,0 +1,3 @@
+# Place all the behaviors and hooks related to the matching controller here.
+# All this logic will automatically be available in application.js.
+# You can use CoffeeScript in this file: http://coffeescript.org/

--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the users controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -1,9 +1,9 @@
 class HomeController < ApplicationController
   before_action :authenticate_user!
   def index
-    if current_user.is_admin == false and current_user.user_applists.where(is_done: false).empty?
+    if current_user.is_reviewer and current_user.user_applists.where(is_done: false).empty?
       #
-      # get no-inreview app
+      # get no-in-review app
       #
       app = Applist.includes(:users).where(users: {id: nil}, is_scraped: true).first
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -49,17 +49,16 @@ class UsersController < ApplicationController
   end
 
   private
-    def authenticate_admin_user!
-      unless current_user.is_admin
-        raise ActionController::RoutingError.new('Not Found')
-      end
+  def authenticate_admin_user!
+    unless current_user.is_admin
+      raise ActionController::RoutingError.new('Not Found')
     end
+  end
 
-    def set_user
-      @user = User.find(params[:id])
-    end
+  def set_user
+    @user = User.find(params[:id])
+  end
 
-    def user_params
-      params.require(:user).permit(:username, :email, :password, :password_confirmation)
-    end
-end
+  def user_params
+    params.require(:user).permit(:username, :email, :password, :password_confirmation)
+  end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,15 +1,70 @@
 class UsersController < ApplicationController
 
-  before_action :authenticate_user!, :authenticate_admin_user!
+  before_action :authenticate_user!
+  before_action :authenticate_admin_user!
+  before_action :set_user, only: [:show, :edit, :update, :destroy]
 
   def index
-    @users = User.all
+    @users = User.where(is_admin: false)
+  end
+
+  def show
+  end
+
+  def new
+    @user = User.new
+  end
+
+  def edit
+  end
+
+  def create
+    @user = User.new(user_params)
+
+    respond_to do |format|
+      if @user.save
+        format.html { redirect_to @user, notice: 'User was successfully created.' }
+      else
+        format.html { render :new }
+      end
+    end
+  end
+
+
+  def update
+    if params[:user][:password].blank?
+      params[:user].delete(:password)
+      params[:user].delete(:password_confirmation)
+    end
+
+    respond_to do |format|
+      if @user.update(user_params)
+        format.html { redirect_to @user, notice: 'User was successfully updated.' }
+      else
+        format.html { render :edit }
+      end
+    end
+  end
+
+  def destroy
+    @user.destroy
+    respond_to do |format|
+      format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
+    end
   end
 
   private
-  def authenticate_admin_user!
-    unless current_user.is_admin
-      raise ActionController::RoutingError.new('Not Found')
+    def authenticate_admin_user!
+      unless current_user.is_admin
+        raise ActionController::RoutingError.new('Not Found')
+      end
     end
-  end
+
+    def set_user
+      @user = User.find(params[:id])
+    end
+
+    def user_params
+      params.require(:user).permit(:username, :email, :password, :password_confirmation)
+    end
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -5,7 +5,7 @@ class UsersController < ApplicationController
   before_action :set_user, only: [:show, :edit, :update, :destroy]
 
   def index
-    @users = User.where(is_admin: false)
+    @users = User.all
   end
 
   def show
@@ -13,6 +13,7 @@ class UsersController < ApplicationController
 
   def new
     @user = User.new
+    @user.is_reviewer = true
   end
 
   def edit
@@ -60,5 +61,5 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.require(:user).permit(:username, :email, :password, :password_confirmation)
+    params.require(:user).permit(:username, :email, :password, :password_confirmation, :is_admin, :is_reviewer)
   end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,15 @@
+class UsersController < ApplicationController
+
+  before_action :authenticate_user!, :authenticate_admin_user!
+
+  def index
+    @users = User.all
+  end
+
+  private
+  def authenticate_admin_user!
+    unless current_user.is_admin
+      raise ActionController::RoutingError.new('Not Found')
+    end
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -21,12 +21,10 @@ class UsersController < ApplicationController
   def create
     @user = User.new(user_params)
 
-    respond_to do |format|
-      if @user.save
-        format.html { redirect_to @user, notice: 'User was successfully created.' }
-      else
-        format.html { render :new }
-      end
+    if @user.save
+      redirect_to @user, notice: 'User was successfully created.'
+    else
+      render :new
     end
   end
 
@@ -37,19 +35,16 @@ class UsersController < ApplicationController
       params[:user].delete(:password_confirmation)
     end
 
-    respond_to do |format|
-      if @user.update(user_params)
-        format.html { redirect_to @user, notice: 'User was successfully updated.' }
-      else
-        format.html { render :edit }
-      end
+    if @user.update(user_params)
+      redirect_to @user, notice: 'User was successfully updated.'
+    else
+      render :edit
     end
   end
 
   def destroy
     @user.destroy
-    respond_to do |format|
-      format.html { redirect_to users_url, notice: 'User was successfully destroyed.' }
+      redirect_to users_url, notice: 'User was successfully destroyed.'
     end
   end
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,7 +2,7 @@ class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,
-         :recoverable, :rememberable, :trackable, :validatable
+         :recoverable, :rememberable, :validatable
 
   has_many :user_applists
   has_many :applists, through: :user_applists do

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,9 +1,5 @@
 <p id="notice"><%= notice %></p>
 
-<% if current_user.is_admin %>
-<h1>Admin Page</h1>
-
-<% else %>
 <h1>My reviewing App</h1>
 
 <% if @reviewing_apps.present? %>
@@ -21,9 +17,9 @@
   <tbody>
     <% @reviewing_apps.each do |applist| %>
       <tr>
-        <td><% if applist.itunes_app %><%= image_tag(applist.itunes_app.icon_url) %><% end %></td>
+        <td><% if applist.itunes_app %><%= image_tag(applist.itunes_app.icon_url, size: "100x100") %><% end %></td>
         <td><% if applist.itunes_app %><%= link_to applist.itunes_app.name, applist.itunes_url %><% end %></td>
-        <td><% if applist.google_play_app %><%= image_tag(applist.google_play_app.icon_url) %><% end %></td>
+        <td><% if applist.google_play_app %><%= image_tag(applist.google_play_app.icon_url, size: "100x100") %><% end %></td>
         <td><% if applist.google_play_app %><%= link_to applist.google_play_app.name, applist.google_play_url %><% end %></td>
         <td><%= button_to 'Review Done!', applist_done_app_path(applist) %></td>
       </tr>
@@ -33,8 +29,3 @@
 <% else %>
 <p>empty Apps</p>
 <% end %>
-
-<% end %>
-
-
-

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,6 +32,7 @@
           <% if user_signed_in? and current_user.is_admin %>
           <ul class="nav navbar-nav">
             <li><%= link_to "Register Apps",  applists_path %></li>
+            <li><%= link_to "User List", users_path %></li>
           </ul>
           <% end %>
           <ul class="nav navbar-nav navbar-right">
@@ -40,7 +41,6 @@
             <li><%= link_to "Settings", edit_user_registration_path %></li>
             <li><%= link_to "Log Out", destroy_user_session_path, method: :delete %></li>
             <% else %>
-            <li><%= link_to "Sign up", new_user_registration_path %></li>
             <li><%= link_to "Login", new_user_session_path %></li>
             <% end %>
           </ul>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -16,34 +16,45 @@
   <% end %>
 
   <div class="form-group">
-    <%= f.label :email, :class => 'control-label col-lg-2' %>
-    <div class="col-lg-10">
+    <%= f.label :email, :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
       <%= f.email_field :email, :class => 'form-control' %>
     </div>
-    <%=f.error_span(:email) %>
   </div>
   <div class="form-group">
-    <%= f.label :username, :class => 'control-label col-lg-2' %>
-    <div class="col-lg-10">
+    <%= f.label :username, :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
       <%= f.text_field :username, :class => 'form-control' %>
     </div>
-    <%=f.error_span(:username) %>
   </div>
 
   <div class="form-group">
-    <%= f.label :password, :class => 'control-label col-lg-2' %>
-    <div class="col-lg-10">
+    <%= f.label :password, :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
       <%= f.password_field :password, autocomplete: "off", :class => 'form-control' %>
     </div>
-    <%=f.error_span(:password) %>
   </div>
 
   <div class="form-group">
-    <%= f.label :password_confirmation, :class => 'control-label col-lg-2' %>
-    <div class="col-lg-10">
+    <%= f.label :password_confirmation, :class => 'control-label col-sm-2' %>
+    <div class="col-sm-10">
       <%= f.password_field :password_confirmation, autocomplete: "off", :class => 'form-control' %>
     </div>
-    <%=f.error_span(:password_confirmation) %>
+  </div>
+
+  <div class="form-group">
+    <div class="col-lg-offset-2 col-lg-10">
+      <div class="checkbox">
+        <%= f.label :is_admin do %>
+          <%= f.check_box :is_admin %> admin ( admin_user can manage apps, create user )
+        <% end %>
+      </div>
+      <div class="checkbox">
+        <%= f.label :is_reviewer do %>
+          <%= f.check_box :is_reviewer %> reviewer ( reviewer will receive app review candidates )
+        <% end %>
+      </div>
+    </div>
   </div>
 
   <div class="form-group">
@@ -53,5 +64,4 @@
                 users_path, :class => 'btn btn-default' %>
     </div>
   </div>
-
 <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -1,0 +1,57 @@
+<%= form_for @user, :html => { :class => "form-horizontal user" } do |f| %>
+
+  <% if @user.errors.any? %>
+    <div id="error_expl" class="panel panel-danger">
+      <div class="panel-heading">
+        <h3 class="panel-title"><%= pluralize(@user.errors.count, "error") %> prohibited this user from being saved:</h3>
+      </div>
+      <div class="panel-body">
+        <ul>
+        <% @user.errors.full_messages.each do |msg| %>
+          <li><%= msg %></li>
+        <% end %>
+        </ul>
+      </div>
+    </div>
+  <% end %>
+
+  <div class="form-group">
+    <%= f.label :email, :class => 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.email_field :email, :class => 'form-control' %>
+    </div>
+    <%=f.error_span(:email) %>
+  </div>
+  <div class="form-group">
+    <%= f.label :username, :class => 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.text_field :username, :class => 'form-control' %>
+    </div>
+    <%=f.error_span(:username) %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :password, :class => 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.password_field :password, autocomplete: "off", :class => 'form-control' %>
+    </div>
+    <%=f.error_span(:password) %>
+  </div>
+
+  <div class="form-group">
+    <%= f.label :password_confirmation, :class => 'control-label col-lg-2' %>
+    <div class="col-lg-10">
+      <%= f.password_field :password_confirmation, autocomplete: "off", :class => 'form-control' %>
+    </div>
+    <%=f.error_span(:password_confirmation) %>
+  </div>
+
+  <div class="form-group">
+    <div class="col-lg-offset-2 col-lg-10">
+      <%= f.submit nil, :class => 'btn btn-primary' %>
+      <%= link_to t('.cancel', :default => t("helpers.links.cancel")),
+                users_path, :class => 'btn btn-default' %>
+    </div>
+  </div>
+
+<% end %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -1,0 +1,5 @@
+<%- model_class = Applist -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => [:'helpers.titles.edit', 'Edit %{model}'], :model => model_class.model_name.human.titleize %></h1>
+</div>
+<%= render :partial => 'form' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -9,6 +9,7 @@
       <th><%= model_class.human_attribute_name(:username) %></th>
       <th><%= model_class.human_attribute_name(:email) %></th>
       <th><%= model_class.human_attribute_name(:is_admin) %></th>
+      <th><%= model_class.human_attribute_name(:is_reviewer) %></th>
       <th><%= model_class.human_attribute_name(:created_at) %></th>
       <th><%=t '.actions', :default => t("helpers.actions") %></th>
     </tr>
@@ -20,6 +21,7 @@
         <td><%= user.username %></td>
         <td><%= user.email %></td>
         <td><%= user.is_admin %></td>
+        <td><%= user.is_reviewer %></td>
         <td><%= user.created_at %></td>
         <td>
           <%= link_to t('.edit', :default => t("helpers.links.edit")),

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,0 +1,38 @@
+<%- model_class = User -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => model_class.model_name.human.pluralize.titleize %></h1>
+</div>
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th><%= model_class.human_attribute_name(:id) %></th>
+      <th><%= model_class.human_attribute_name(:email) %></th>
+      <th><%= model_class.human_attribute_name(:username) %></th>
+      <th><%= model_class.human_attribute_name(:created_at) %></th>
+      <th><%=t '.actions', :default => t("helpers.actions") %></th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @users.each do |user| %>
+      <tr>
+        <td><%= link_to user.id, user_path(user) %></td>
+        <td><%= user.email %></td>
+        <td><%= user.username %></td>
+        <td><%= user.created_at %></td>
+        <td>
+          <%= link_to t('.edit', :default => t("helpers.links.edit")),
+                      edit_user_path(user), :class => 'btn btn-default btn-xs' %>
+          <%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+                      user_path(user),
+                      :method => :delete,
+                      :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+                      :class => 'btn btn-xs btn-danger' %>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<%= link_to t('.new', :default => t("helpers.links.new")),
+            new_user_path,
+            :class => 'btn btn-primary' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -6,8 +6,9 @@
   <thead>
     <tr>
       <th><%= model_class.human_attribute_name(:id) %></th>
-      <th><%= model_class.human_attribute_name(:email) %></th>
       <th><%= model_class.human_attribute_name(:username) %></th>
+      <th><%= model_class.human_attribute_name(:email) %></th>
+      <th><%= model_class.human_attribute_name(:is_admin) %></th>
       <th><%= model_class.human_attribute_name(:created_at) %></th>
       <th><%=t '.actions', :default => t("helpers.actions") %></th>
     </tr>
@@ -16,8 +17,9 @@
     <% @users.each do |user| %>
       <tr>
         <td><%= link_to user.id, user_path(user) %></td>
-        <td><%= user.email %></td>
         <td><%= user.username %></td>
+        <td><%= user.email %></td>
+        <td><%= user.is_admin %></td>
         <td><%= user.created_at %></td>
         <td>
           <%= link_to t('.edit', :default => t("helpers.links.edit")),

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,0 +1,5 @@
+<%- model_class = User -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => [:'helpers.titles.new', 'New %{model}'], :model => model_class.model_name.human.titleize %></h1>
+</div>
+<%= render :partial => 'form' %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -36,8 +36,4 @@
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
-
-<p>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?" }, method: :delete %></p>
-
 <%= link_to "Back", :back %>

--- a/app/views/users/registrations/edit.html.erb
+++ b/app/views/users/registrations/edit.html.erb
@@ -4,6 +4,11 @@
   <%= devise_error_messages! %>
 
   <div class="field">
+    <%= f.label :username %><br />
+    <%= f.text_field :username %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true %>
   </div>

--- a/app/views/users/shared/_links.html.erb
+++ b/app/views/users/shared/_links.html.erb
@@ -2,10 +2,6 @@
   <%= link_to "Log in", new_session_path(resource_name) %><br />
 <% end -%>
 
-<%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name) %><br />
-<% end -%>
-
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
   <%= link_to "Forgot your password?", new_password_path(resource_name) %><br />
 <% end -%>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -10,6 +10,8 @@
   <dd><%= @user.email %></dd>
   <dt><strong><%= model_class.human_attribute_name(:is_admin) %>:</strong></dt>
   <dd><%= @user.is_admin %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:is_reviewer) %>:</strong></dt>
+  <dd><%= @user.is_reviewer %></dd>
   <dt><strong><%= model_class.human_attribute_name(:created_at) %>:</strong></dt>
   <dd><%= @user.created_at %></dd>
 </dl>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,25 @@
+<%- model_class = User -%>
+<div class="page-header">
+  <h1><%=t '.title', :default => model_class.model_name.human.titleize %></h1>
+</div>
+
+<dl class="dl-horizontal">
+  <dt><strong><%= model_class.human_attribute_name(:username) %>:</strong></dt>
+  <dd><%= @user.username %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:email) %>:</strong></dt>
+  <dd><%= @user.email %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:is_admin) %>:</strong></dt>
+  <dd><%= @user.is_admin %></dd>
+  <dt><strong><%= model_class.human_attribute_name(:created_at) %>:</strong></dt>
+  <dd><%= @user.created_at %></dd>
+</dl>
+
+<%= link_to t('.back', :default => t("helpers.links.back")),
+              users_path, :class => 'btn btn-default'  %>
+<%= link_to t('.edit', :default => t("helpers.links.edit")),
+              edit_user_path(@user), :class => 'btn btn-default' %>
+<%= link_to t('.destroy', :default => t("helpers.links.destroy")),
+              user_path(@user),
+              :method => 'delete',
+              :data => { :confirm => t('.confirm', :default => t("helpers.links.confirm", :default => 'Are you sure?')) },
+              :class => 'btn btn-danger' %>

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -3,3 +3,13 @@ require_relative 'application'
 
 # Initialize the Rails application.
 Rails.application.initialize!
+
+ActionMailer::Base.smtp_settings = {
+  :address        => 'smtp.sendgrid.net',
+  :port           => '587',
+  :authentication => :plain,
+  :user_name      => ENV['SENDGRID_USERNAME'],
+  :password       => ENV['SENDGRID_PASSWORD'],
+  :domain         => 'heroku.com',
+  :enable_starttls_auto => true
+}

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -29,10 +29,13 @@ Rails.application.configure do
   # Don't care if the mailer can't send.
   config.action_mailer.raise_delivery_errors = false
 
+  config.action_mailer.delivery_method = :letter_opener
+
   config.action_mailer.perform_caching = false
 
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000 }
   # Print deprecation notices to the Rails logger.
+
   config.active_support.deprecation = :log
 
   # Raise an error on page load if there are pending migrations.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -18,6 +18,7 @@ Rails.application.configure do
   # Apache or NGINX already handles this.
   config.public_file_server.enabled = ENV['RAILS_SERVE_STATIC_FILES'].present?
 
+  config.action_mailer.default_url_options = { host: ENV['HOST_URL'] }
   # Compress JavaScripts and CSS.
   config.assets.js_compressor = :uglifier
   # config.assets.css_compressor = :sass

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'please-change-me-at-config-initializers-devise@example.com'
+  config.mailer_sender = 'noreply@example.com'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -12,7 +12,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class
   # with default "from" parameter.
-  config.mailer_sender = 'noreply@example.com'
+  config.mailer_sender = "noreply@#{ENV['HOST_URL']}"
 
   # Configure the class responsible to send e-mails.
   # config.mailer = 'Devise::Mailer'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,6 +8,10 @@ Rails.application.routes.draw do
     post :scrape_app
     post :done_app
   end
-  devise_for :users
-
+  devise_for :users, skip: [:registrations]
+  as :user do
+    get 'users/edit' => 'devise/registrations#edit', :as => 'edit_user_registration'
+    put 'users' => 'devise/registrations#update', :as => 'user_registration'
+  end
+  resources :users # for Admin
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -14,4 +14,8 @@ Rails.application.routes.draw do
     put 'users' => 'devise/registrations#update', :as => 'user_registration'
   end
   resources :users # for Admin
+
+  if Rails.env.development?
+    mount LetterOpenerWeb::Engine, at: "/letter_opener"
+  end
 end

--- a/db/fixtures/user.rb
+++ b/db/fixtures/user.rb
@@ -1,0 +1,7 @@
+User.seed do |s|
+  s.id = 1
+  s.username = "admin"
+  s.email    = "admin@example.com"
+  s.password = ENV['ADMIN_PASSWORD']
+  s.is_admin = true
+end

--- a/db/migrate/20160820070137_add_collumn_to_user.rb
+++ b/db/migrate/20160820070137_add_collumn_to_user.rb
@@ -1,0 +1,5 @@
+class AddCollumnToUser < ActiveRecord::Migration[5.0]
+  def change
+    add_column :users, :is_reviewer, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160724163321) do
+ActiveRecord::Schema.define(version: 20160820070137) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20160724163321) do
     t.datetime "updated_at",                             null: false
     t.string   "username"
     t.boolean  "is_admin",               default: false
+    t.boolean  "is_reviewer",            default: false
     t.index ["email"], name: "index_users_on_email", unique: true, using: :btree
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  test "should get index" do
+    get users_index_url
+    assert_response :success
+  end
+
+end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,9 +1,0 @@
-require 'test_helper'
-
-class UsersControllerTest < ActionDispatch::IntegrationTest
-  test "should get index" do
-    get users_index_url
-    assert_response :success
-  end
-
-end


### PR DESCRIPTION
https://github.com/kitaindia/lagoon-mgr/issues/15

https://github.com/kitaindia/lagoon-mgr/issues/16

関連issueです

**概要**
管理者だけ一般ユーザー（レビューをしてくれるユーザー）を新規登録できる。

・ユーザーは、メールアドレスや、パスワードを変更できる
管理者の初期メールアドレス・パスワードは仮のものだし、セキュリティ的に個々人のユーザーがパスワードを自分でできたほうがいいのでこのような仕様にしました。

・パスワードを忘れた時のメールの設定を行った
sendgridでメール送信を行えるようにした。ユーザーがパスワードを忘れた時の再設定用メールを送る用。上記の通り基本は管理者はユーザーを登録するときはパスワードは仮パスワードで登録するだけにし、パスワードはユーザーが個々に管理しておくほうがよいので。

**やったこと**
- 初期データで管理者ユーザーを登録できるようにした(rake db:seed_fu で追加される)
- 管理者は、一般ユーザーを追加・編集・削除できる
- 一般ユーザーは、自分で新規登録できない
- 一般ユーザーは、編集はできるがアカウントを削除できない
